### PR TITLE
Set key when passing metadata, content feeds directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -693,10 +693,10 @@ Hyperdrive.prototype._open = function (cb) {
     if (err) return cb(err)
     self.metadata.ready(function (err) {
       if (err) return cb(err)
-      if (self.content) return cb(null)
-
       self.key = self.metadata.key
       self.discoveryKey = self.metadata.discoveryKey
+
+      if (self.content) return cb(null)
 
       if (!self.metadata.writable || self._checkout) onnotwriteable()
       else onwritable()

--- a/test/storage.js
+++ b/test/storage.js
@@ -70,3 +70,20 @@ tape('dir storage without permissions emits error', function (t) {
     t.ok(err, 'got error')
   })
 })
+
+tape('construct archive from feeds', function (t) {
+  var source = create()
+  source.writeFile('/hello.txt', 'world', function (err) {
+    t.error(err, 'no error')
+
+    var archive = create({metadata: source.metadata, content: source.content})
+    archive.ready(function () {
+      t.same(archive.key && archive.key.toString('hex'), source.key.toString('hex'), 'key matches')
+      archive.readFile('/hello.txt', 'utf8', function (err, data) {
+        t.error(err, 'no error')
+        t.same(data, 'world')
+        t.end()
+      })
+    })
+  })
+})


### PR DESCRIPTION
Creating archive from feeds, key is never set:

```js
var archive = hyperdrive(storage, {metadata: source.metadata, content: source.content})
archive.key // null
archive.ready(function () {
  archive.key // null
})
```

Fixes #175 