### PR TITLE
checkout replication test

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "protocol-buffers": "^4.0.2",
+    "pump": "^3.0.0",
     "random-access-memory": "^2.3.0",
     "standard": "^9.0.2",
     "tape": "^4.6.3",


### PR DESCRIPTION
This patch adds a skipped test for `.replicate()` on a read-only archive created with checkout. This feature is very similar to the also-skipped download test. Because checkouts are (for now) read-only, I would imagine that the replication would only work one-way, the same as setting `clone.replicate({ download: false })`. I'm not sure why but right now the streams hang despite having live mode set to false.