### PR TITLE
_latestStorage now closed with archive.

### DIFF
--- a/index.js
+++ b/index.js
@@ -784,8 +784,17 @@ Hyperdrive.prototype.close = function (fd, cb) {
   this.ready(function (err) {
     if (err) return cb(err)
     self.metadata.close(function (err) {
-      if (!self.content) return cb(err)
-      self.content.close(cb)
+      if (err) return cb(err)
+      if (!self.content) {
+        if (!self._latestStorage) return cb()
+        self._latestStorage.close(cb)
+      } else {
+        self.content.close(function (err) {
+          if(err) return cb(err)
+          if (!self._latestStorage) return cb()
+          self._latestStorage.close(cb)
+        })
+      }
     })
   })
 }


### PR DESCRIPTION
_latestStorage was not being closed when the archive was closed. This lead to file descriptors being left open. This prevented an archive from being created, closed, and then deleted from disk in the same process.