### PR TITLE
Adding a mirror method

### DIFF
--- a/index.js
+++ b/index.js
@@ -935,7 +935,7 @@ class Hyperdrive extends Nanoresource {
     // Getting all the mounts will trigger the event listeners above.
     this.getAllMounts({ content: true }, (err, mounts) => {
       if (err) return this.emit('error', err)
-      for (const [, { metadata, content }] of mounts) {
+      for (const { metadata, content } of mounts.values()) {
         oncore(metadata)
         oncore(content)
       }
@@ -957,7 +957,7 @@ class Hyperdrive extends Nanoresource {
     function oncore (core) {
       if (!core) return
       if (!self._mirrorRanges || self._mirrorRanges.has(core)) return
-      self._mirrorRanges.set(core, core.download())
+      self._mirrorRanges.set(core, core.download({ start: 0, end: -1 }))
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ class Hyperdrive extends Nanoresource {
     this._fds = []
     this._writingFds = new Map()
     this._unlistens = []
-    this._mirrorRanges = null
+    this._unmirror = null
 
     this._metadataOpts = {
       key,
@@ -927,8 +927,8 @@ class Hyperdrive extends Nanoresource {
 
   mirror () {
     const self = this
-    if (this._mirrorRanges) return unmirror
-    this._mirrorRanges = new Map()
+    if (this._unmirror) return this._unmirror
+    const mirrorRanges = new Map()
 
     this.on('content-feed', oncore)
     this.on('metadata-feed', oncore)
@@ -941,23 +941,23 @@ class Hyperdrive extends Nanoresource {
       }
     })
 
-    return unmirror
+    this._unmirror = unmirror
+    return this._unmirror
 
     function unmirror () {
-      if (!self._mirrorRanges) return
-      const ranges = self._mirrorRanges
-      self._mirrorRanges = null
+      if (!self._unmirror) return
+      self._unmirror = null
       self.removeListener('content-feed', oncore)
       self.removeListener('metadata-feed', oncore)
-      for (const [ core, range ] of ranges) {
+      for (const [ core, range ] of mirrorRanges) {
         core.undownload(range)
       }
     }
 
     function oncore (core) {
       if (!core) return
-      if (!self._mirrorRanges || self._mirrorRanges.has(core)) return
-      self._mirrorRanges.set(core, core.download({ start: 0, end: -1 }))
+      if (!self._unmirror || mirrorRanges.has(core)) return
+      mirrorRanges.set(core, core.download({ start: 0, end: -1 }))
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -932,7 +932,6 @@ class Hyperdrive extends Nanoresource {
 
     this.on('content-feed', oncore)
     this.on('metadata-feed', oncore)
-    // Getting all the mounts will trigger the event listeners above.
     this.getAllMounts({ content: true }, (err, mounts) => {
       if (err) return this.emit('error', err)
       for (const { metadata, content } of mounts.values()) {
@@ -956,7 +955,7 @@ class Hyperdrive extends Nanoresource {
 
     function oncore (core) {
       if (!core) return
-      if (!self._unmirror || mirrorRanges.has(core)) return
+      if (!self._unmirror || self._unmirror !== unmirror || mirrorRanges.has(core)) return
       mirrorRanges.set(core, core.download({ start: 0, end: -1 }))
     }
   }

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -72,6 +72,8 @@ function statIterator (drive, path, opts) {
 }
 
 function mountIterator (drive, opts) {
+  const loadContent = !!(opts && opts.content)
+
   var ite = null
   var first = drive
 
@@ -86,7 +88,7 @@ function mountIterator (drive, opts) {
     next (cb) {
       if (first) {
         first = null
-        if (drive.metadata.has(0)) {
+        if (loadContent || drive.metadata.has(0)) {
           return drive._getContent(drive.db.feed, err => {
             if (err) return cb(err)
             return cb(null, {
@@ -110,7 +112,7 @@ function mountIterator (drive, opts) {
         const contentState = drive._contentStates.cache.get(val.trie.feed)
         let mountMetadataFeed = val.trie.feed
         if (contentState) return process.nextTick(oncontent, val.path, mountMetadataFeed, contentState)
-        if (!mountMetadataFeed.has(0)) return oncontent(val.path, mountMetadataFeed, null)
+        if (!loadContent && !mountMetadataFeed.has(0)) return oncontent(val.path, mountMetadataFeed, null)
         return drive._getContent(val.trie.feed, (err, contentState) => {
           if (err) return cb(err)
           return oncontent(val.path, mountMetadataFeed, contentState)


### PR DESCRIPTION
Right now `download` is used to download the latest versions of specific files/directories within a drive. It'd be possible to extend this to support downloading all previous versions of those files/directories as well, but doing so might complicate the usage (i.e. `drive.download('/my-directory', { allVersions: true})`.

The UX there gets even trickier when considering mounts. What if `/my-directory` was previously a mount? It can get hard to reason about.

This PR adds a `mirror` method that does a full sync of a drive's metadata/content at the Hypercore level. It currently syncs all mounts as well, but this can be made configurable in the future. 

Any thoughts on introducing an additional method for this behavior? 