### PR TITLE
Remove listeners on close

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,6 +133,14 @@ class Hyperdrive extends Nanoresource {
       self.metadata.on('peer-add', peeradd)
       self.metadata.on('peer-remove', peerremove)
 
+      this.once('close', () => {
+        self.metadata.removeListener('error', onerror)
+        self.metadata.removeListener('append', update)
+        self.metadata.removeListener('extension', extension)
+        self.metadata.removeListener('peer-add', peeradd)
+        self.metadata.removeListener('peer-remove', peerremove)
+      })
+
       return self.metadata.ready(err => {
         if (err) return done(err)
 
@@ -232,7 +240,9 @@ class Hyperdrive extends Nanoresource {
       return cb(err)
     }
 
-    feed.on('error', err => this.emit('error', err))
+    const contentErrorListener = err => this.emit('error', err)
+    feed.on('error', contentErrorListener)
+    this.once('close', () => feed.removeListener('error', contentErrorListener))
     feed.ready(err => {
       if (err) return cb(err)
       this.emit('content-feed', feed)

--- a/index.js
+++ b/index.js
@@ -121,11 +121,8 @@ class Hyperdrive extends Nanoresource {
         feed: this.metadata,
         sparse: this.sparseMetadata
       })
-      this.db.on('hypertrie', trie => {
-        this.emit('metadata-feed', trie.feed)
-        this.emit('mount', trie)
-      })
-      this.db.on('error', err => this.emit('error', err))
+      this.db.on('hypertrie', onhypertrie)
+      this.db.on('error', onerror)
 
       self.metadata.on('error', onerror)
       self.metadata.on('append', update)
@@ -134,6 +131,8 @@ class Hyperdrive extends Nanoresource {
       self.metadata.on('peer-remove', peerremove)
 
       this.once('close', () => {
+        self.db.removeListener('error', onerror)
+        self.db.removeListener('hypertrie', onhypertrie)
         self.metadata.removeListener('error', onerror)
         self.metadata.removeListener('append', update)
         self.metadata.removeListener('extension', extension)
@@ -218,6 +217,11 @@ class Hyperdrive extends Nanoresource {
 
     function peerremove(peer) {
       self.emit('peer-remove', peer)
+    }
+
+    function onhypertrie (trie) {
+      self.emit('metadata-feed', trie.feed)
+      self.emit('mount', trie)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ class Hyperdrive extends Nanoresource {
     this._contentStates = opts._contentStates || new ThunkyMap(this._contentStateFromMetadata.bind(this))
     this._fds = []
     this._writingFds = new Map()
+    this._unlistens = []
 
     this._metadataOpts = {
       key,
@@ -130,7 +131,7 @@ class Hyperdrive extends Nanoresource {
       self.metadata.on('peer-add', peeradd)
       self.metadata.on('peer-remove', peerremove)
 
-      this.once('close', () => {
+      this._unlistens.push(() => {
         self.db.removeListener('error', onerror)
         self.db.removeListener('hypertrie', onhypertrie)
         self.metadata.removeListener('error', onerror)
@@ -246,7 +247,7 @@ class Hyperdrive extends Nanoresource {
 
     const contentErrorListener = err => this.emit('error', err)
     feed.on('error', contentErrorListener)
-    this.once('close', () => feed.removeListener('error', contentErrorListener))
+    this._unlistens.push(() => feed.removeListener('error', contentErrorListener))
     feed.ready(err => {
       if (err) return cb(err)
       this.emit('content-feed', feed)
@@ -807,6 +808,10 @@ class Hyperdrive extends Nanoresource {
 
   _close (cb) {
     this.db.close(err => {
+      for (const unlisten of this._unlistens) {
+        unlisten()
+      }
+      this._unlistens = []
       this.emit('close')
       cb(err)
     })

--- a/index.js
+++ b/index.js
@@ -806,7 +806,7 @@ class Hyperdrive extends Nanoresource {
   }
 
   _close (cb) {
-    this.corestore.close((err) => {
+    this.db.close(err => {
       this.emit('close')
       cb(err)
     })


### PR DESCRIPTION
The metadata/content feeds might not be closed when the drive is closed (they might be mounted elsewhere, or being passively replicated in the corestore). If we don't remove these listeners, the drive state will be leaked after close.