### PR TITLE
Added peer-open event

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ drive.on('peer-add', (peer) => {
 })
 ```
 
+#### `drive.on('peer-open', peer)`
+
+Emitted when a peer has been added and has finished handshaking.
+
 #### `drive.on('peer-remove', peer)`
 
 Emitted when a peer has been removed.

--- a/index.js
+++ b/index.js
@@ -131,6 +131,7 @@ class Hyperdrive extends Nanoresource {
       self.metadata.on('append', update)
       self.metadata.on('extension', extension)
       self.metadata.on('peer-add', peeradd)
+      self.metadata.on('peer-open', peeropen)
       self.metadata.on('peer-remove', peerremove)
 
       this._unlistens.push(() => {
@@ -140,6 +141,7 @@ class Hyperdrive extends Nanoresource {
         self.metadata.removeListener('append', update)
         self.metadata.removeListener('extension', extension)
         self.metadata.removeListener('peer-add', peeradd)
+        self.metadata.removeListener('peer-open', peeropen)
         self.metadata.removeListener('peer-remove', peerremove)
       })
 
@@ -216,6 +218,10 @@ class Hyperdrive extends Nanoresource {
 
     function peeradd(peer) {
       self.emit('peer-add', peer)
+    }
+
+    function peeropen(peer) {
+      self.emit('peer-open', peer)
     }
 
     function peerremove(peer) {


### PR DESCRIPTION
This was added in the latest hypercore to signal handshaking being completed and is important for extensions to work properly.

Goes along side `peer-add` and `peer-remove`