### PR TITLE
Add headerType, defaults to hyperdrive

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ class Hyperdrive extends Nanoresource {
     this.live = true
     this.sparse = opts.sparse !== false
     this.sparseMetadata = opts.sparseMetadata !== false
-    this.headerSubtype = opts.headerSubtype || 'hyperdrive'
+    this.subtype = opts.subtype || 'hyperdrive'
 
     this.promises = new HyperdrivePromises(this)
 
@@ -129,7 +129,7 @@ class Hyperdrive extends Nanoresource {
         feed: this.metadata,
         sparse: this.sparseMetadata,
         extension: this.opts.extension !== false,
-        headerSubtype: this.headerSubtype
+        subtype: this.subtype
       })
       this.db.on('hypertrie', onhypertrie)
       this.db.on('error', onerror)

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ class Hyperdrive extends Nanoresource {
     this.live = true
     this.sparse = opts.sparse !== false
     this.sparseMetadata = opts.sparseMetadata !== false
+    this.headerType = opts.headerType || 'hyperdrive'
 
     this.promises = new HyperdrivePromises(this)
 
@@ -127,7 +128,8 @@ class Hyperdrive extends Nanoresource {
       this.db = this.db || new MountableHypertrie(this.corestore, this.key, {
         feed: this.metadata,
         sparse: this.sparseMetadata,
-        extension: this.opts.extension !== false
+        extension: this.opts.extension !== false,
+        headerType: this.headerType
       })
       this.db.on('hypertrie', onhypertrie)
       this.db.on('error', onerror)

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ class Hyperdrive extends Nanoresource {
     this.live = true
     this.sparse = opts.sparse !== false
     this.sparseMetadata = opts.sparseMetadata !== false
-    this.headerType = opts.headerType || 'hyperdrive'
+    this.headerSubtype = opts.headerSubtype || 'hyperdrive'
 
     this.promises = new HyperdrivePromises(this)
 
@@ -129,7 +129,7 @@ class Hyperdrive extends Nanoresource {
         feed: this.metadata,
         sparse: this.sparseMetadata,
         extension: this.opts.extension !== false,
-        headerType: this.headerType
+        headerSubtype: this.headerSubtype
       })
       this.db.on('hypertrie', onhypertrie)
       this.db.on('error', onerror)


### PR DESCRIPTION
Adds support for the `headerType` option to track the `type` in the hypercore header.

Fixes #294 