### PR TITLE
Use name when generating content feed

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,8 @@ class Hyperdrive extends Nanoresource {
      * The first time the hyperdrive is created, we initialize both the db (metadata feed) and the content feed here.
      */
     function initialize () {
-      self._contentStateFromKey(null, (err, contentState) => {
+      const contentName = self.metadata.key.toString('hex') + '-content'
+      self._contentStateFromOpts({ name: contentName }, (err, contentState) => {
         if (err) return done(err)
         // warm up the thunky map
         self._contentStates.cache.set(self.db.feed, contentState)
@@ -255,7 +256,12 @@ class Hyperdrive extends Nanoresource {
   }
 
   _contentStateFromKey (publicKey, cb) {
-    const contentOpts = { key: publicKey, ...contentOptions(this), cache: { data: false } }
+    this._contentStateFromOpts({ key: publicKey }, cb)
+  }
+
+  _contentStateFromOpts (opts, cb) {
+    const contentOpts = { ...opts, ...contentOptions(this), cache: { data: false } }
+    
     try {
       var feed = this.corestore.get(contentOpts)
     } catch (err) {

--- a/test/storage.js
+++ b/test/storage.js
@@ -142,7 +142,6 @@ tape('sparse read/write two files', function (t) {
   })
 })
 
-
 tape('destroying the drive destroys its data', function (t) {
   tmp(function (err, dir, cleanup) {
     t.ifError(err)
@@ -158,11 +157,38 @@ tape('destroying the drive destroys its data', function (t) {
           t.deepEqual(files, [], 'archive now empty')
           copy.close(function (err) {
             t.ifError(err)
-            cleanup(function(err) {
+            cleanup(function (err) {
               t.ifError(err)
               t.end()
             })
           })
+        })
+      })
+    })
+  })
+})
+
+tape('content feed gets generated consistently', function (t) {
+  const masterKey = Buffer.from('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 'hex')
+
+  const drive1 = create(null, { masterKey, namespace: 'test' })
+
+  drive1.ready(function (err) {
+    t.ifError(err)
+
+    const drive2 = create(null, { masterKey, namespace: 'test' })
+
+    drive2.ready(function (err) {
+      t.ifError(err)
+      t.deepEqual(drive1.key, drive2.key, 'consistent metadata')
+
+      drive1.db.getMetadata(function (err, metadata1) {
+        t.ifError(err)
+        drive2.db.getMetadata(function (err, metadata2) {
+          t.ifError(err)
+          t.deepEqual(metadata1, metadata2, 'consistent content feed')
+
+          t.end()
         })
       })
     })


### PR DESCRIPTION
At the moment content feeds aren't using corestore's namespace feature for deriving their private key. This makes backups a little harder since you need to keep track of both keypairs and need some way of injecting both private keys into the hyperdrive (only the metadata one is easy it seems).

This change uses corestore's `namespace` feature to derive the private key of the content feed based on the key of the metadata feed and some extra text.

With this in place, hyperdrives are generated more predictably, and hyperdrives generated with a name can be re-generated on other devices for backup restoration purposes.

Does this approach make sense? Wanted to get a bit of review before I added unit tests and docs.