### PR TITLE
Change to 'new' constructor pattern 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ npm install hyperdrive
 Hyperdrive aims to implement the same API as Node.js' core `fs` module, and mirrors many POSIX APIs.
 
 ``` js
-var hyperdrive = require('hyperdrive')
-var drive = hyperdrive('./my-first-hyperdrive') // content will be stored in this folder
+var Hyperdrive = require('hyperdrive')
+var drive = new Hyperdrive('./my-first-hyperdrive') // content will be stored in this folder
 
 drive.writeFile('/hello.txt', 'world', function (err) {
   if (err) throw err
@@ -61,7 +61,7 @@ server.listen(10000)
 
 // ... on another
 
-var clonedDrive = hyperdrive('./my-cloned-hyperdrive', origKey)
+var clonedDrive = new Hyperdrive('./my-cloned-hyperdrive', origKey)
 var socket = net.connect(10000)
 
 socket.pipe(clonedDrive.replicate()).pipe(socket)
@@ -71,7 +71,7 @@ It also comes with build in versioning, live replication (where the replication 
 
 ## API
 
-#### `var drive = hyperdrive(storage, [key], [options])`
+#### `var drive = new Hyperdrive(storage, [key], [options])`
 
 Create a new Hyperdrive.
 
@@ -156,7 +156,7 @@ Emitted when there is a new update to the drive. Not triggered unless you load t
 Emitted when a new peer has been added.
 
 ```js
-const drive = Hyperdrive()
+const drive = new Hyperdrive()
 
 drive.on('peer-add', (peer) => {
   console.log('Connected peer', peer.remotePublicKey)

--- a/index.js
+++ b/index.js
@@ -1274,6 +1274,7 @@ class Hyperdrive extends Nanoresource {
 
 function HyperdriveCompat (...args) {
   if (!(this instanceof HyperdriveCompat)) return new HyperdriveCompat(...args)
+  Nanoresource.call(this)
   Hyperdrive.prototype._initialize.call(this, ...args)
 }
 Object.setPrototypeOf(HyperdriveCompat.prototype, Hyperdrive.prototype)

--- a/index.js
+++ b/index.js
@@ -31,13 +31,16 @@ const STDIO_CAP = 20
 const WRITE_STREAM_BLOCK_SIZE = 524288
 const NOOP_FILE_PATH = ' '
 
-module.exports = (...args) => new Hyperdrive(...args)
+module.exports = HyperdriveCompat
 module.exports.constants = require('filesystem-constants').linux
 
 class Hyperdrive extends Nanoresource {
   constructor (storage, key, opts) {
     super()
+    this._initialize(storage, key, opts)
+  }
 
+  _initialize (storage, key, opts) {
     if (isObject(key)) {
       opts = key
       key = null
@@ -1268,6 +1271,12 @@ class Hyperdrive extends Nanoresource {
     return this.tags.get(name, cb)
   }
 }
+
+function HyperdriveCompat (...args) {
+  if (!(this instanceof HyperdriveCompat)) return new HyperdriveCompat(...args)
+  Hyperdrive.prototype._initialize.call(this, ...args)
+}
+Object.setPrototypeOf(HyperdriveCompat.prototype, Hyperdrive.prototype)
 
 function isObject (val) {
   return !!val && typeof val !== 'string' && !Buffer.isBuffer(val)

--- a/test/helpers/create.js
+++ b/test/helpers/create.js
@@ -1,10 +1,10 @@
 var ram = require('random-access-memory')
-var hyperdrive = require('../../')
+var Hyperdrive = require('../../')
 
 module.exports = function (key, opts) {
   if (key && !(key instanceof Buffer)) {
     opts = key
     key = null
   }
-  return hyperdrive((opts && opts.corestore) || ram, key, opts)
+  return new Hyperdrive((opts && opts.corestore) || ram, key, opts)
 }


### PR DESCRIPTION
Remains backwards-compat with function-call instantiation.

See https://github.com/hypercore-protocol/hyperbee/pull/19 for history