### PR TITLE
Update storage.js

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,14 +1,16 @@
 const raf = require('random-access-file')
 const Corestore = require('corestore')
+const join = require('path').join
 
 module.exports = function defaultCorestore (storage, opts) {
   if (isCorestore(storage)) return storage
-  if (typeof storage === 'function') {
-    var factory = path => storage(path)
-  } else if (typeof storage === 'string') {
-    factory = path => raf(storage + '/' + path)
+  
+  switch (typeof storage) {
+    case 'function': return new Corestore(path => storage(path), opts)
+    case 'string': return new Corestore(path => raf(join(storage, path), opts))
+    default:
+      throw new Error('hyperdrive expects "storage" of type function|string, but got ' + typeof storage)
   }
-  return new Corestore(factory, opts)
 }
 
 function isCorestore (storage) {


### PR DESCRIPTION
defaultCorestore didn't have an "else" case, and it' also assume unix directory seperators "/".
this patch would fix those problems