### PR TITLE
Temp fix sparse windows + Passing settings to corestore(bug fix)

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,18 +1,32 @@
-const raf = require('random-access-file')
-const Corestore = require('corestore')
-const join = require('path').join
+const raf = require('random-access-file');
+const Corestore = require('corestore');
+const join = require('path').join;
+const fsctl = require('fsctl');
 
-module.exports = function defaultCorestore (storage, opts) {
-  if (isCorestore(storage)) return storage
-  
+module.exports = function defaultCorestore(storage, opts) {
+  if (isCorestore(storage)) return storage;
+  let factory = null;
+  console.log(storage);
   switch (typeof storage) {
-    case 'function': return new Corestore(path => storage(path), opts)
-    case 'string': return new Corestore(path => raf(join(storage, path), opts))
+    case 'function':
+      return new Corestore((path) => storage(path), opts);
+    case 'string':
+      const sparseWin =
+        opts.sparseWin && process.platform === 'win32'
+          ? fsctl.sparse
+          : opts.sparse;
+      return new Corestore(
+        (path) => raf(join(storage, path), { ...opts, sparse: sparseWin }),
+        opts
+      );
     default:
-      throw new Error('hyperdrive expects "storage" of type function|string, but got ' + typeof storage)
+      throw new Error(
+        'hyperdrive expects "storage" of type function|string, but got ' +
+          typeof storage
+      );
   }
-}
+};
 
-function isCorestore (storage) {
-  return storage.default && storage.get && storage.replicate && storage.close
+function isCorestore(storage) {
+  return storage.default && storage.get && storage.replicate && storage.close;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "custom-error-class": "^1.0.0",
         "duplexify": "^3.7.1",
         "filesystem-constants": "^1.0.0",
+        "fsctl": "^1.0.0",
         "hypercore-byte-stream": "^1.0.2",
         "hypercore-protocol": "^8.0.7",
         "hyperdrive-schemas": "^2.0.0",
@@ -580,7 +581,6 @@
       "resolved": "https://registry.npmjs.org/fsctl/-/fsctl-1.0.0.tgz",
       "integrity": "sha512-uNHlfhyUJiVO2kHA6ZBnDkBhG1wM8fII+xGfCi5aBoWR7DLh9Q3nOAWe4fEETQzkptahITI1xbe5r23HuA5ECA==",
       "hasInstallScript": true,
-      "optional": true,
       "dependencies": {
         "napi-macros": "^2.0.0",
         "node-gyp-build": "^4.2.3"
@@ -2613,7 +2613,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fsctl/-/fsctl-1.0.0.tgz",
       "integrity": "sha512-uNHlfhyUJiVO2kHA6ZBnDkBhG1wM8fII+xGfCi5aBoWR7DLh9Q3nOAWe4fEETQzkptahITI1xbe5r23HuA5ECA==",
-      "optional": true,
       "requires": {
         "napi-macros": "^2.0.0",
         "node-gyp-build": "^4.2.3"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "custom-error-class": "^1.0.0",
     "duplexify": "^3.7.1",
     "filesystem-constants": "^1.0.0",
+    "fsctl": "^1.0.0",
     "hypercore-byte-stream": "^1.0.2",
     "hypercore-protocol": "^8.0.7",
     "hyperdrive-schemas": "^2.0.0",


### PR DESCRIPTION
Temporary fix to enable sparse on windows.

Also not sure about the opts but saw that they where not passed to the corestore when `case: 'string'`. So passed the options there also.
before
`return new Corestore(path => raf(join(storage, path), opts))`
now
`return new Corestore((path) => raf(join(storage, path), { ...opts, sparse: sparseWin }), opts);`

And if you are wondering about the spread operator I use it for overwriting the sparse only in the `raf()`. So it don't mess with other stuff when option `sparseWin` is true. Not sure if needed but wanted to be on the safe side.